### PR TITLE
Fix formatting in Application Version section

### DIFF
--- a/source/service-standards.html.md.erb
+++ b/source/service-standards.html.md.erb
@@ -92,7 +92,7 @@ This means that we accept a `traceparent` header which can then be used to corre
 
 ### Application version
 All our requests are also augmented with the current version of the application to help identify when issues first occurred and link back to the correct code.
-This is of format <date>.<circleci job number>.<github reference> so can be traced back not only to the circleci job that built the code, but also the github commit of the code.
+This is of format `<date>.<circleci job number>.<github reference>` so can be traced back not only to the circleci job that built the code, but also the github commit of the code.
 
 [openapi-3]: https://www.gov.uk/government/publications/recommended-open-standards-for-government/describing-restful-apis-with-openapi-3 "Describing RESTful APIs with OpenAPI 3"
 [azure-monitor]: https://docs.microsoft.com/en-us/azure/azure-monitor/ "Azure Monitor documentation"


### PR DESCRIPTION
Noticed that because the `<` tags weren't wrapped in backticks it meant that Middleman did not show them, see picture below:
![image](https://user-images.githubusercontent.com/2437376/137276424-700588ed-f09b-405b-89ec-268b9af3294b.png)
